### PR TITLE
[CI][GCE/5] Add GCE flavors of job and runtime-env tests

### DIFF
--- a/release/air_tests/air_benchmarks/compute_gce_gpu_1.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_1.yaml
@@ -1,0 +1,27 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n1-highmem-32-nvidia-tesla-v100-4 # aws g3.8xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-8 # m5.2xlarge
+      max_workers: 0
+      min_workers: 0
+      use_spot: false
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            Iops: 5000
+#            Throughput: 1000
+#            VolumeSize: 1000
+#            VolumeType: gp3

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_16.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_16.yaml
@@ -1,0 +1,28 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 3
+
+head_node_type:
+    name: head_node
+    instance_type: n1-highmem-32-nvidia-tesla-v100-4 # aws g3.16xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n1-highmem-32-nvidia-tesla-v100-4  # aws g3.16xlarge
+      max_workers: 3
+      min_workers: 3
+      use_spot: false
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 800
+#            Iops: 5000
+#            Throughput: 1000
+#            VolumeSize: 1000
+#            VolumeType: gp3

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_1_g4_8xl.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_1_g4_8xl.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n1-standard-16-nvidia-tesla-t4-1 # aws g4dn.8xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-8 # m5.2xlarge
+      max_workers: 0
+      min_workers: 0
+      use_spot: false

--- a/release/air_tests/air_benchmarks/compute_gce_gpu_4_g4_12xl.yaml
+++ b/release/air_tests/air_benchmarks/compute_gce_gpu_4_g4_12xl.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+max_workers: 3
+
+head_node_type:
+    name: head_node
+    instance_type: n1-highmem-32-nvidia-tesla-v100-4 # g4dn.12xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n1-highmem-32-nvidia-tesla-v100-4 # g4dn.12xlarge
+      max_workers: 3
+      min_workers: 3
+      use_spot: false

--- a/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/app_config_oom.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_CPU"] | default("anyscale/ray-ml:2.0.1-py37-cpu") }}
+base_image: {{ env["RAY_IMAGE_ML_NIGHTLY_CPU"] | default("anyscale/ray-ml:2.3.1-py37-cpu") }}
 env_vars: {"RAY_task_oom_retries": "50", "RAY_min_memory_free_bytes": "1000000000"}
 debian_packages:
   - curl

--- a/release/air_tests/air_benchmarks/mlperf-train/compute_gce_cpu_16.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/compute_gce_cpu_16.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # aws m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # m5.xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+
+#aws:
+#    BlockDeviceMappings:
+#        - DeviceName: /dev/sda1
+#          Ebs:
+#            DeleteOnTermination: true
+#            VolumeSize: 400

--- a/release/air_tests/air_benchmarks/mlperf-train/compute_gce_cpu_16_worker_nodes_2.yaml
+++ b/release/air_tests/air_benchmarks/mlperf-train/compute_gce_cpu_16_worker_nodes_2.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 2
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # aws m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # m5.xlarge
+      min_workers: 2
+      max_workers: 2
+      use_spot: false

--- a/release/jobs_tests/compute_tpl_gce_4_xlarge.yaml
+++ b/release/jobs_tests/compute_tpl_gce_4_xlarge.yaml
@@ -1,0 +1,24 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 4
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-4 # m5.xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # m5.xlarge
+      min_workers: 4
+      max_workers: 4
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '24'

--- a/release/jobs_tests/compute_tpl_gce_gpu_node.yaml
+++ b/release/jobs_tests/compute_tpl_gce_gpu_node.yaml
@@ -1,0 +1,22 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+head_node_type:
+    name: head_node
+    instance_type: n1-standard-16-nvidia-tesla-t4-1 # g4dn.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-16 # aws m5.4xlarge
+      min_workers: 1
+      max_workers: 1
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '24'

--- a/release/jobs_tests/compute_tpl_gce_gpu_worker.yaml
+++ b/release/jobs_tests/compute_tpl_gce_gpu_worker.yaml
@@ -1,0 +1,22 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-a
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-16 # aws m5.4xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n1-standard-16-nvidia-tesla-t4-1 # g4dn.4xlarge
+      min_workers: 1
+      max_workers: 1
+      use_spot: false
+
+#aws:
+#  TagSpecifications:
+#    - ResourceType: "instance"
+#      Tags:
+#        - Key: ttl-hours
+#          Value: '24'

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2042,8 +2042,13 @@
     wait_for_nodes:
       num_nodes: 4
 
-
   alert: default
+
+  flavors:
+    - name: aws
+    - name: gce
+      env: gce
+      cluster_compute: compute_tpl_gce_4_xlarge.yaml
 
 - name: jobs_basic_remote_working_dir
   group: Jobs tests
@@ -2062,6 +2067,12 @@
     wait_for_nodes:
       num_nodes: 4
 
+  flavors:
+    - name: aws
+    - name: gce
+      env: gce
+      cluster_compute: compute_tpl_gce_4_xlarge.yaml
+
 
   alert: default
 
@@ -2078,6 +2089,11 @@
     script: python workloads/jobs_remote_multi_node.py
     wait_for_nodes:
       num_nodes: 4
+  flavors:
+    - name: aws
+    - name: gce
+      env: gce
+      cluster_compute: compute_tpl_gce_4_xlarge.yaml
 
 - name: jobs_check_cuda_available
   group: Jobs tests
@@ -2092,6 +2108,11 @@
     script: python workloads/jobs_check_cuda_available.py
     wait_for_nodes:
       num_nodes: 2
+  flavors:
+    - name: aws
+    - name: gce
+      env: gce
+      cluster_compute: compute_tpl_gce_gpu_node.yaml
 
 - name: jobs_specify_num_gpus
   group: Jobs tests
@@ -2106,6 +2127,11 @@
     script: python workloads/jobs_specify_num_gpus.py --working-dir "workloads"
     wait_for_nodes:
       num_nodes: 2
+  flavors:
+    - name: aws
+    - name: gce
+      env: gce
+      cluster_compute: compute_tpl_gce_gpu_worker.yaml
 
 
 ########################

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2154,8 +2154,13 @@
     wait_for_nodes:
       num_nodes: 4
 
-
   alert: default
+
+  flavors:
+    - name: aws
+    - name: gce
+      env: gce
+      cluster_compute: rte_gce_small.yaml
 
 - name: runtime_env_wheel_urls
   group: Runtime env tests
@@ -2174,8 +2179,13 @@
     wait_for_nodes:
       num_nodes: 1
 
-
   alert: default
+
+  flavors:
+    - name: aws
+    - name: gce
+      env: gce
+      cluster_compute: rte_gce_minimal.yaml
 
 # It seems like the consensus is that this should be tested in CI, and not in a nightly test.
 

--- a/release/runtime_env_tests/rte_gce_minimal.yaml
+++ b/release/runtime_env_tests/rte_gce_minimal.yaml
@@ -1,0 +1,18 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-4 # aws m5.xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # aws m5.xlarge
+      min_workers: 0
+      max_workers: 0
+      use_spot: false
+

--- a/release/runtime_env_tests/rte_gce_small.yaml
+++ b/release/runtime_env_tests/rte_gce_small.yaml
@@ -1,0 +1,17 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west1
+allowed_azs: 
+    - us-west1-c
+
+max_workers: 3
+
+head_node_type:
+    name: head_node
+    instance_type: n2-standard-4 # aws m5.xlarge
+
+worker_node_types:
+    - name: worker_node
+      instance_type: n2-standard-4 # aws m5.xlarge
+      min_workers: 3
+      max_workers: 3
+      use_spot: false


### PR DESCRIPTION
## Why are these changes needed?

We start to onboard customers using GCE on Anyscale stack. It is essential now that we also run release tests on GCE.

Adding GCE flavors for some job and runtime-env tests

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Release tests
   